### PR TITLE
Add a descriptive message to mismatch errors.

### DIFF
--- a/pkg/commands/check.go
+++ b/pkg/commands/check.go
@@ -173,7 +173,8 @@ func (co *checkOptions) RunE(cmd *cobra.Command, args []string) error {
 
 		for range co.boilerplateLines[1:] {
 			if !scanner.Scan() {
-				cmd.Printf("%s:%d: incomplete boilerplate\n", path, idx)
+				cmd.Printf("%s:%d: incomplete boilerplate, missing:\n%s", path, idx,
+					strings.Join(co.boilerplateLines[len(lines):], "\n"))
 				return nil
 			}
 
@@ -185,7 +186,7 @@ func (co *checkOptions) RunE(cmd *cobra.Command, args []string) error {
 		// isn't part of the diff, then reviewdog will filter the error.
 		for i := range lines {
 			if co.boilerplateLines[i] != lines[i] {
-				cmd.Printf("%s:%d: %s", path, idx+i, cmp.Diff(co.boilerplateLines[i:], lines[i:]))
+				cmd.Printf("%s:%d: found mismatched boilerplate lines:\n%s", path, idx+i, cmp.Diff(co.boilerplateLines[i:], lines[i:]))
 				break
 			}
 		}

--- a/pkg/commands/testdata/https.bad.mm
+++ b/pkg/commands/testdata/https.bad.mm
@@ -5,7 +5,15 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+// Package foo builds widgets
+package foo

--- a/pkg/commands/testdata/tab.bad.mm
+++ b/pkg/commands/testdata/tab.bad.mm
@@ -5,7 +5,15 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+// Package foo builds widgets
+package foo

--- a/pkg/commands/testdata/trimmed.bad.mm
+++ b/pkg/commands/testdata/trimmed.bad.mm
@@ -1,11 +1,18 @@
 /*
 Copyright 2020 Matt Moore
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-
     http://www.apache.org/licenses/LICENSE-2.0
-
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package foo builds widgets
+package foo
+
+func bar() {
+}


### PR DESCRIPTION
Fixes: https://github.com/mattmoor/boilerplate-check/issues/9