### PR TITLE
fix --fix: avoid duplicate boilerplate

### DIFF
--- a/pkg/commands/check.go
+++ b/pkg/commands/check.go
@@ -34,6 +34,7 @@ import (
 var (
 	ErrBoilerplateRequired   = errors.New("--boilerplate is a required flag.")
 	ErrFileExtensionRequired = errors.New("--file-extension is a required flag.")
+	ErrBoilerplateExists     = errors.New("boilerplate already exists in file")
 )
 
 // NewCheckCommand implements the `check` sub-command
@@ -163,6 +164,12 @@ func (co *checkOptions) RunE(cmd *cobra.Command, args []string) error {
 		if !found {
 			if co.Fix {
 				if err := co.fixMissingBoilerplate(path); err != nil {
+					if errors.Is(err, ErrBoilerplateExists) {
+						// Boilerplate exists beyond line 10, don't modify the file
+						cmd.Printf("%s: boilerplate found beyond line 10, not in expected location\n", path)
+						co.issuesFound = true
+						return nil
+					}
 					return err
 				}
 				co.issuesFound = true

--- a/pkg/commands/check_test.go
+++ b/pkg/commands/check_test.go
@@ -229,37 +229,51 @@ func TestCheckFix(t *testing.T) {
 	tests := []struct {
 		desc          string
 		inputFile     string
+		boilerplate   string
+		fileExtension string
 		wantExitError bool
 		wantNoChanges bool
 		wantFixed     bool
 	}{{
 		desc:          "typo in copyright name",
 		inputFile:     "testdata/typo.bad.mm",
+		boilerplate:   "testdata/boilerplate.mm.txt",
+		fileExtension: "mm",
 		wantExitError: true,
 		wantFixed:     false,
 	}, {
 		desc:          "incomplete boilerplate",
 		inputFile:     "testdata/short.bad.mm",
+		boilerplate:   "testdata/boilerplate.mm.txt",
+		fileExtension: "mm",
 		wantExitError: true,
 		wantFixed:     false,
 	}, {
 		desc:          "missing boilerplate",
 		inputFile:     "testdata/missing.bad.mm",
+		boilerplate:   "testdata/boilerplate.mm.txt",
+		fileExtension: "mm",
 		wantExitError: true,
 		wantFixed:     true,
 	}, {
 		desc:          "https instead of http",
 		inputFile:     "testdata/https.bad.mm",
+		boilerplate:   "testdata/boilerplate.mm.txt",
+		fileExtension: "mm",
 		wantExitError: true,
 		wantFixed:     false,
 	}, {
 		desc:          "tab instead of spaces",
 		inputFile:     "testdata/tab.bad.mm",
+		boilerplate:   "testdata/boilerplate.mm.txt",
+		fileExtension: "mm",
 		wantExitError: true,
 		wantFixed:     false,
 	}, {
 		desc:          "correct boilerplate with old year",
 		inputFile:     "testdata/old.good.mm",
+		boilerplate:   "testdata/boilerplate.mm.txt",
+		fileExtension: "mm",
 		wantNoChanges: true,
 	}}
 
@@ -273,7 +287,7 @@ func TestCheckFix(t *testing.T) {
 				t.Fatalf("Failed to read input file: %v", err)
 			}
 
-			testFile := filepath.Join(tmpDir, "test.mm")
+			testFile := filepath.Join(tmpDir, "test."+tt.fileExtension)
 			if err := os.WriteFile(testFile, inputContent, 0644); err != nil {
 				t.Fatalf("Failed to write test file: %v", err)
 			}
@@ -292,8 +306,8 @@ func TestCheckFix(t *testing.T) {
 			output := new(bytes.Buffer)
 			cmd.SetOut(output)
 			cmd.SetArgs([]string{
-				"--boilerplate", filepath.Join(originalWd, "testdata/boilerplate.mm.txt"),
-				"--file-extension", "mm",
+				"--boilerplate", filepath.Join(originalWd, tt.boilerplate),
+				"--file-extension", tt.fileExtension,
 				"--fix",
 			})
 
@@ -324,8 +338,8 @@ func TestCheckFix(t *testing.T) {
 				output2 := new(bytes.Buffer)
 				cmd2.SetOut(output2)
 				cmd2.SetArgs([]string{
-					"--boilerplate", filepath.Join(originalWd, "testdata/boilerplate.mm.txt"),
-					"--file-extension", "mm",
+					"--boilerplate", filepath.Join(originalWd, tt.boilerplate),
+					"--file-extension", tt.fileExtension,
 				})
 
 				if err := cmd2.Execute(); err != nil {

--- a/pkg/commands/testdata/boilerplate.sh.txt
+++ b/pkg/commands/testdata/boilerplate.sh.txt
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Matt Moore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/pkg/commands/testdata/old-year.bad.mm
+++ b/pkg/commands/testdata/old-year.bad.mm
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Chainguard, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+echo "Hello world"

--- a/pkg/commands/testdata/old-year.bad.sh
+++ b/pkg/commands/testdata/old-year.bad.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 Matt Moore
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Hello world"


### PR DESCRIPTION
This aims to fix an issue where `boilerplate-check --fix` on files that already had a boilerplate with an older year would result in duplicate boilerplates.
